### PR TITLE
Fixing the publish/append example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ select *
   from transaction_history
  where action_date > last_publish_date
 """
+hf = HyperFile(name="transaction_history", sql=new_data, is_dbfs_enabled=True)
+
 hf.append(tableau_server_url,
           username,
           password,

--- a/README.md
+++ b/README.md
@@ -52,14 +52,7 @@ select *
   from transaction_history
  where action_date > last_publish_date
 """
-hf = HyperFile(name="transaction_history", sql=new_data, is_dbfs_enabled=True)
-
-hf.append(tableau_server_url,
-          username,
-          password,
-          site_name,
-          project_name,
-          datasource_name)
+hf.append(sql=new_data)
 ```
 
 ## Legal Information


### PR DESCRIPTION
The README example for `publish` followed by `append` did not include an update to `hf`. I'm assuming this is a necessary step before appending.