### PR TITLE
Exposing Hyper Process Parameters

### DIFF
--- a/hyperleaup/creator.py
+++ b/hyperleaup/creator.py
@@ -322,7 +322,10 @@ class Creator:
 
             # COPY data into a Tableau .hyper file
             logging.info("Copying data into Hyper File...")
-            database_path = copy_parquet_to_hyper_file(parquet_path, self.name, table_def, self.hyper_process_parameters)
+            database_path = copy_parquet_to_hyper_file(parquet_path,
+                                                       self.name,
+                                                       table_def,
+                                                       self.hyper_process_parameters)
 
         else:
             raise ValueError(f'Invalid "creation_mode" specified: {self.creation_mode}')

--- a/hyperleaup/creator.py
+++ b/hyperleaup/creator.py
@@ -322,9 +322,7 @@ class Creator:
 
             # COPY data into a Tableau .hyper file
             logging.info("Copying data into Hyper File...")
-            database_path = copy_parquet_to_hyper_file(parquet_path,
-                                                       self.name,
-                                                       table_def,
+            database_path = copy_parquet_to_hyper_file(parquet_path, self.name, table_def,
                                                        self.hyper_process_parameters)
 
         else:

--- a/hyperleaup/hyper_file.py
+++ b/hyperleaup/hyper_file.py
@@ -51,7 +51,8 @@ class HyperFile:
 
     def print_rows(self):
         """Prints the first 1,000 rows of a Hyper file"""
-        with HyperProcess(telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU, parameters=self.hyper_process_parameters) as hp:
+        with HyperProcess(telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU,
+                          parameters=self.hyper_process_parameters) as hp:
             with Connection(endpoint=hp.endpoint, database=self.path) as connection:
                 rows = connection.execute_list_query(f"SELECT * FROM {TableName('Extract', 'Extract')} LIMIT 1000")
                 print("Showing first 1,000 rows")
@@ -60,7 +61,8 @@ class HyperFile:
 
     def print_table_def(self, schema: str = "Extract", table: str = "Extract"):
         """Prints the table definition for a table in a Hyper file."""
-        with HyperProcess(telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU, parameters=self.hyper_process_parameters) as hp:
+        with HyperProcess(telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU,
+                          parameters=self.hyper_process_parameters) as hp:
             with Connection(endpoint=hp.endpoint, database=self.path) as connection:
                 table_name = TableName(schema, table)
                 table_definition = connection.catalog.get_table_definition(name=table_name)
@@ -179,7 +181,8 @@ class HyperFile:
         # Insert, the new data into Hyper File
         hyper_database_path = self.path
         logging.info(f'Inserting new data into Hyper database: {hyper_database_path}')
-        with HyperProcess(telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU, parameters=self.hyper_process_parameters) as hp:
+        with HyperProcess(telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU,
+                          parameters=self.hyper_process_parameters) as hp:
             with Connection(endpoint=hp.endpoint,
                             database=hyper_database_path,
                             create_mode=CreateMode.NONE) as connection:

--- a/hyperleaup/hyper_file.py
+++ b/hyperleaup/hyper_file.py
@@ -1,6 +1,7 @@
 import os
 import logging
 from shutil import copyfile
+from typing import Mapping
 
 from pyspark.sql import DataFrame
 from tableauhyperapi import HyperProcess, Telemetry, Connection, CreateMode, Inserter
@@ -22,7 +23,8 @@ class HyperFile:
                  sql: str = None, df: DataFrame = None,
                  is_dbfs_enabled: bool = False,
                  creation_mode: str = CreationMode.PARQUET.value,
-                 null_values_replacement: dict = None):
+                 null_values_replacement: dict = None,
+                 hyper_process_parameters: Mapping[str, str] = None):
         self.name = name
         # Create a DataFrame from Spark SQL
         if sql is not None and df is None:
@@ -33,6 +35,7 @@ class HyperFile:
         self.creation_mode = creation_mode
         self.is_dbfs_enabled = is_dbfs_enabled
         self.null_values_replacement = null_values_replacement
+        self.hyper_process_parameters = hyper_process_parameters
         # Do not create a Hyper File if loading an existing Hyper File
         if sql is None and df is None:
             self.path = None
@@ -41,12 +44,14 @@ class HyperFile:
                                 self.name,
                                 self.is_dbfs_enabled,
                                 self.creation_mode,
-                                self.null_values_replacement).create()
+                                self.null_values_replacement,
+                                self.hyper_process_parameters
+                                ).create()
         self.luid = None
 
     def print_rows(self):
         """Prints the first 1,000 rows of a Hyper file"""
-        with HyperProcess(telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU) as hp:
+        with HyperProcess(telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU, parameters=self.hyper_process_parameters) as hp:
             with Connection(endpoint=hp.endpoint, database=self.path) as connection:
                 rows = connection.execute_list_query(f"SELECT * FROM {TableName('Extract', 'Extract')} LIMIT 1000")
                 print("Showing first 1,000 rows")
@@ -55,7 +60,7 @@ class HyperFile:
 
     def print_table_def(self, schema: str = "Extract", table: str = "Extract"):
         """Prints the table definition for a table in a Hyper file."""
-        with HyperProcess(telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU) as hp:
+        with HyperProcess(telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU, parameters=self.hyper_process_parameters) as hp:
             with Connection(endpoint=hp.endpoint, database=self.path) as connection:
                 table_name = TableName(schema, table)
                 table_definition = connection.catalog.get_table_definition(name=table_name)
@@ -108,7 +113,7 @@ class HyperFile:
         return copyfile(self.path, dest_path)
 
     @staticmethod
-    def load(path: str, is_dbfs_enabled: bool = False):
+    def load(path: str, is_dbfs_enabled: bool = False, hyper_process_parameters: Mapping[str, str] = None):
         """Loads a Hyper File from a source path to a temp dir"""
         # Guard against invalid paths
         if path.lower().startswith("s3"):
@@ -151,7 +156,7 @@ class HyperFile:
             hyper_file_path = path
 
         # Create a HyperFile object with existing Hyper File path
-        hf = HyperFile(name=name, is_dbfs_enabled=is_dbfs_enabled)
+        hf = HyperFile(name=name, is_dbfs_enabled=is_dbfs_enabled, hyper_process_parameters=hyper_process_parameters)
         hf.path = hyper_file_path
 
         return hf
@@ -174,7 +179,7 @@ class HyperFile:
         # Insert, the new data into Hyper File
         hyper_database_path = self.path
         logging.info(f'Inserting new data into Hyper database: {hyper_database_path}')
-        with HyperProcess(telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU) as hp:
+        with HyperProcess(telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU, parameters=self.hyper_process_parameters) as hp:
             with Connection(endpoint=hp.endpoint,
                             database=hyper_database_path,
                             create_mode=CreateMode.NONE) as connection:

--- a/hyperleaup/hyper_file.py
+++ b/hyperleaup/hyper_file.py
@@ -45,8 +45,7 @@ class HyperFile:
                                 self.is_dbfs_enabled,
                                 self.creation_mode,
                                 self.null_values_replacement,
-                                self.hyper_process_parameters
-                                ).create()
+                                self.hyper_process_parameters).create()
         self.luid = None
 
     def print_rows(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tableauserverclient==0.17.0
 pyspark==3.1.3
 requests==2.26.0
-tableauhyperapi==0.0.13129
+tableauhyperapi==0.0.16638
 urllib3==1.26.6

--- a/tests/test_hyper_file.py
+++ b/tests/test_hyper_file.py
@@ -25,7 +25,7 @@ class TestHyperFile(object):
             (104, "Management"),
             (105, "HR")
         ]
-        get_spark_session() \
+        get_spark_session()\
             .createDataFrame(data, ["id", "department"]) \
             .createOrReplaceGlobalTempView("departments")
         sql = "SELECT * FROM global_temp.departments"
@@ -50,7 +50,7 @@ class TestHyperFile(object):
         ]
         df = get_spark_session().createDataFrame(data, ["id", "first_name", "last_name", "dob", "age", "is_temp"])
         hf = HyperFile(name="employees", df=df, is_dbfs_enabled=False, creation_mode="insert")
-        assert (hf.path == "/tmp/hyperleaup/employees/employees.hyper")
+        assert(hf.path == "/tmp/hyperleaup/employees/employees.hyper")
 
     def test_save(self):
         data = [
@@ -68,18 +68,18 @@ class TestHyperFile(object):
         hf.save(new_path)
 
         # Save operation should not update the current Hyper File's path
-        assert (current_path == hf.path)
-        assert (os.path.exists(expected_path))
-        assert (os.path.isfile(expected_path))
+        assert(current_path == hf.path)
+        assert(os.path.exists(expected_path))
+        assert(os.path.isfile(expected_path))
 
     def test_load(self):
         # Ensure that existing Hyper Files can be loaded
         existing_hf_path = '/tmp/save/employees.hyper'
-        assert (os.path.exists(existing_hf_path))
-        assert (os.path.isfile(existing_hf_path))
+        assert(os.path.exists(existing_hf_path))
+        assert(os.path.isfile(existing_hf_path))
         hf = HyperFile.load(path=existing_hf_path, is_dbfs_enabled=False)
-        assert (hf.path == existing_hf_path)
-        assert (hf.name == 'employees')
+        assert(hf.path == existing_hf_path)
+        assert(hf.name == 'employees')
 
     def test_append(self):
         # Ensure that new data can be appended to an existing Hyper File
@@ -97,7 +97,7 @@ class TestHyperFile(object):
         df = get_spark_session().createDataFrame(data, ["id", "first_name", "last_name", "dob", "age", "is_temp"])
         hf.append(df=df)
         num_rows = TestUtils.get_row_count("Extract", "Extract", "/tmp/save/employees.hyper")
-        assert (num_rows == 6)
+        assert(num_rows == 6)
 
     def test_hyper_process_parameters(self):
         data_path = "/tmp/process_parameters"
@@ -124,5 +124,5 @@ class TestHyperFile(object):
                       hyper_process_parameters=hyper_process_parameters).save(data_path)
 
             # Make sure that the logs have been created in the non-standard location
-            assert (os.path.exists(log_file))
-            assert (os.path.isfile(log_file))
+            assert(os.path.exists(log_file))
+            assert(os.path.isfile(log_file))

--- a/tests/test_hyper_file.py
+++ b/tests/test_hyper_file.py
@@ -100,6 +100,8 @@ class TestHyperFile(object):
         assert (num_rows == 6)
 
     def test_hyper_process_parameters(self):
+        data_path = "/tmp/process_parameters"
+
         log_dir = "/tmp/logs"
         log_file = f"{log_dir}/hyperd.log"
         if not os.path.exists(log_dir):
@@ -112,17 +114,15 @@ class TestHyperFile(object):
         ]
         df = get_spark_session().createDataFrame(data, ["id", "first_name", "last_name", "dob", "age", "is_temp"])
 
+        hyper_process_parameters = {"log_dir": log_dir}
+
         for mode in ["insert", "copy", "parquet"]:
             if os.path.exists(log_file):
                 os.remove(log_file)
 
-            hf = HyperFile(name="employees", df=df, is_dbfs_enabled=False, creation_mode=mode,
-                           hyper_process_parameters={"log_dir": log_dir})
+            HyperFile(name="employees", df=df, is_dbfs_enabled=False, creation_mode=mode,
+                      hyper_process_parameters=hyper_process_parameters).save(data_path)
 
-            # Ensure that the Hyper File can be saved to an alternative location
-            new_path = '/tmp/save/'
-            hf.save(new_path)
-
-            # Save operation should not update the current Hyper File's path
+            # Make sure that the logs have been created in the non-standard location
             assert (os.path.exists(log_file))
             assert (os.path.isfile(log_file))

--- a/tests/test_hyper_file.py
+++ b/tests/test_hyper_file.py
@@ -1,5 +1,4 @@
 import os
-
 from hyperleaup import HyperFile
 from hyperleaup.spark_fixture import get_spark_session
 from tests.test_utils import TestUtils
@@ -26,7 +25,7 @@ class TestHyperFile(object):
             (105, "HR")
         ]
         get_spark_session()\
-            .createDataFrame(data, ["id", "department"]) \
+            .createDataFrame(data, ["id", "department"])\
             .createOrReplaceGlobalTempView("departments")
         sql = "SELECT * FROM global_temp.departments"
         hf = HyperFile(name="employees", sql=sql)
@@ -86,7 +85,7 @@ class TestHyperFile(object):
         existing_hf_path = '/tmp/save/employees.hyper'
         hf = HyperFile.load(path=existing_hf_path, is_dbfs_enabled=False)
         num_rows = TestUtils.get_row_count("Extract", "Extract", "/tmp/save/employees.hyper")
-        assert (num_rows == 3)
+        assert(num_rows == 3)
 
         # Create new data
         data = [


### PR DESCRIPTION
**Why this change?**
When running this library in a read-only location (e.g. a Databricks Repo with only read permissions) the process will fail as the hyperd.log file cannot be written. In order to come around that the parameters of the HyperProcess need to be exposed. With that you can for example disable the logging ("log_config": "") or change the path to where the log should be written ("log_dir": "my/log/dir").  